### PR TITLE
(SIMP-3138) Fix non-partition /boot

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Fri May 05 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.2-0
+- Created a work-around for an undocumented issue where /boot is not
+  on its own paritition but is added to the kernel parameters with
+  fips=1. This situation ends up creating a kernel panic on the
+  system until the boot= entry is removed from the kernel boot line.
+- Added tests against GCE since that is the default image configuration
+  on those systems.
+
 * Thu Mar 23 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.1.1-0
 - The simp_options::fips catalyst did not disable fips; changed enable
   variable to default to simp_options::fips

--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ group :system_tests do
   # This patch is required to fix Beaker's broken `aio` handling and provide support for SuSE
   # If you want to use 'bundle update --local', comment out this line and uncomment the next line
   # If you do this, please remember not to check in that change.
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-978-2.51.0'
-  # gem 'beaker'
+  gem 'google-api-client'
+  gem 'beaker', '~> 3.15.0'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,11 +40,20 @@ class fips (
       }
 
       # This should only be present if /boot is on a separate partition
-      if $facts['boot_dir_uuid'] and ($facts['boot_dir_uuid'] != $facts['root_dir_uuid']) {
-        kernel_parameter { 'boot':
-          value  => "UUID=${facts['boot_dir_uuid']}",
-          notify => Reboot_notify['fips'];
-          # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
+      if $facts['boot_dir_uuid'] and $facts['root_dir_uuid'] {
+        if ($facts['boot_dir_uuid'] == $facts['root_dir_uuid']) {
+          kernel_parameter { 'boot':
+            ensure => absent,
+            notify => Reboot_notify['fips'];
+            # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
+          }
+        }
+        else {
+          kernel_parameter { 'boot':
+            value  => "UUID=${facts['boot_dir_uuid']}",
+            notify => Reboot_notify['fips'];
+            # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
+          }
         }
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 # sure these affect are understood before changing the status.
 #
 # @param enabled
-#   If FIPS should be enable or disabled on the system.
+#   If FIPS should be enabled or disabled on the system.
 #
 # @param aesni
 #   NOTE: This parameter is controlled by params.pp
@@ -20,9 +20,7 @@ class fips (
 ) inherits fips::params {
 
   case $facts['os']['family'] {
-
     'RedHat': {
-
       $fips_kernel_value = $enabled ? {
         true    => '1',
         default => '0'
@@ -35,21 +33,26 @@ class fips (
         default => 'absent'
       }
 
-      kernel_parameter {
-        'fips':
-          value  => $fips_kernel_value,
+      kernel_parameter { 'fips':
+        value  => $fips_kernel_value,
+        notify => Reboot_notify['fips']
+        # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
+      }
+
+      # This should only be present if /boot is on a separate partition
+      if $facts['boot_dir_uuid'] and ($facts['boot_dir_uuid'] != $facts['root_dir_uuid']) {
+        kernel_parameter { 'boot':
+          value  => "UUID=${facts['boot_dir_uuid']}",
           notify => Reboot_notify['fips'];
           # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
-        'boot':
-          value  => "UUID=${::boot_dir_uuid}",
-          notify => Reboot_notify['fips'];
-          # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
+        }
       }
 
       package {
         'dracut-fips':
           ensure => $fips_package_status,
           notify => Exec['dracut_rebuild'];
+
         'fipscheck':
           ensure => latest
       }
@@ -59,11 +62,13 @@ class fips (
           ensure => $fips_package_status,
           notify => Exec['dracut_rebuild']
         }
+
         # There were failures if the packages are not removed/installed in the correct
         # order
         if $enabled {
           Package['dracut-fips'] -> Package['dracut-fips-aesni']
-        } else {
+        }
+        else {
           Package['dracut-fips-aesni'] -> Package['dracut-fips']
         }
       }
@@ -81,7 +86,7 @@ class fips (
       }
     }
     default : {
-      fail('Only the RedHat family is supported by the simp fips module at this time.')
+      fail("Only the RedHat family is supported by the ${module_name} module at this time.")
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-fips",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author":  "SIMP Team",
   "summary": "A SIMP module for managing FIPS",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.3.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/suites/gce/init_spec.rb
+++ b/spec/acceptance/suites/gce/init_spec.rb
@@ -1,0 +1,1 @@
+../default/init_spec.rb

--- a/spec/acceptance/suites/gce/nodesets/default.yml
+++ b/spec/acceptance/suites/gce/nodesets/default.yml
@@ -1,0 +1,21 @@
+HOSTS:
+  el7:
+    roles:
+      - server
+      - default
+      - master
+    platform:   rhel-7-v20170426
+    hypervisor: google
+  el6:
+    roles:
+      - client
+    platform:   rhel-6-v20170426
+    hypervisor: google
+CONFIG:
+  log_level: verbose
+  type:      aio
+  keyfile:  ADD_ME
+  gce_project: ADD_ME
+  gce_keyfile: ADD_ME
+  gce_password: notasecret
+  gce_email: ADD_ME

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -5,7 +5,8 @@ describe 'fips' do
     on_supported_os.each do |os, facts|
       let(:facts){
         facts.merge({
-        :boot_dir_uuid => '123-456-789'
+        :root_dir_uuid => '123-456-789',
+        :boot_dir_uuid => '123-456-790'
       }) }
 
       context "on #{os}" do
@@ -25,15 +26,35 @@ describe 'fips' do
             is_expected.to create_package('dracut-fips').that_notifies('Exec[dracut_rebuild]')
             is_expected.to create_package('fipscheck').with_ensure('latest')
           }
-          it { is_expected.to create_kernel_parameter('boot').with_value("UUID=123-456-789") }
+          it { is_expected.to create_kernel_parameter('boot').with_value("UUID=123-456-790") }
           it { is_expected.to create_kernel_parameter('boot').that_notifies('Reboot_notify[fips]') }
           it { is_expected.to create_reboot_notify('fips') }
+
+          context 'when boot is not a separate partition' do
+            let(:facts){
+              facts.merge({
+              :root_dir_uuid => '123-456-789',
+              :boot_dir_uuid => '123-456-789'
+            }) }
+
+            it { is_expected.to compile.with_all_deps }
+            it {
+              is_expected.to create_kernel_parameter('fips').with_value('1')
+              is_expected.to create_kernel_parameter('fips').that_notifies('Reboot_notify[fips]')
+              is_expected.to create_package('dracut-fips').with_ensure('latest')
+              is_expected.to create_package('dracut-fips').that_notifies('Exec[dracut_rebuild]')
+              is_expected.to create_package('fipscheck').with_ensure('latest')
+            }
+            it { is_expected.to_not create_kernel_parameter('boot') }
+            it { is_expected.to create_reboot_notify('fips') }
+          end
         end
 
         context 'when_enabling_fips and aes' do
           let(:facts){ facts.merge({
             :cpuinfo => { :processor0 => { :flags => ['aes'] }},
-            :boot_dir_uuid => '123-456-789'
+            :root_dir_uuid => '123-456-789',
+            :boot_dir_uuid => '123-456-790'
           })}
           let(:params){{
             :enabled => true
@@ -47,7 +68,7 @@ describe 'fips' do
             is_expected.to create_package('dracut-fips-aesni').that_notifies('Exec[dracut_rebuild]')
             is_expected.to create_package('fipscheck').with_ensure('latest')
           }
-          it { is_expected.to create_kernel_parameter('boot').with_value("UUID=123-456-789") }
+          it { is_expected.to create_kernel_parameter('boot').with_value("UUID=123-456-790") }
           it { is_expected.to create_kernel_parameter('boot').that_notifies('Reboot_notify[fips]') }
           it { is_expected.to create_reboot_notify('fips') }
         end
@@ -55,7 +76,8 @@ describe 'fips' do
         context 'when_disabling_fips and aes' do
           let(:facts){ facts.merge({
             :cpuinfo => { :processor0 => { :flags => ['aes'] }},
-            :boot_dir_uuid => '123-456-789'
+            :root_dir_uuid => '123-456-789',
+            :boot_dir_uuid => '123-456-790'
           })}
 
           let(:params){{

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,7 +45,7 @@ describe 'fips' do
               is_expected.to create_package('dracut-fips').that_notifies('Exec[dracut_rebuild]')
               is_expected.to create_package('fipscheck').with_ensure('latest')
             }
-            it { is_expected.to_not create_kernel_parameter('boot') }
+            it { is_expected.to create_kernel_parameter('boot').with_ensure('absent') }
             it { is_expected.to create_reboot_notify('fips') }
           end
         end


### PR DESCRIPTION
This works around an undocumented issue where /boot is not on its own
paritition but is added to the kernel parameters with fips=1.

This situation ends up creating a kernel panic on the system until the
boot= entry is removed from the kernel boot line.

Added tests against GCE since that is the default image configuration
on those systems.

SIMP-3138 #close