### PR TITLE
(SIMP-3115) Pin enabled state to system state

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri May 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.3-0
+- Including the FIPS module was causing FIPS mode to be enabled by default.
+  This had high potential for causing issues, as evidenced by our acceptance
+  tests, so we now mirror the 'enabled' state of the module based on whether or
+  not FIPS is already enabled on the target system.
+
 * Fri May 05 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.2-0
 - Created a work-around for an undocumented issue where /boot is not
   on its own paritition but is added to the kernel parameters with

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,13 +9,17 @@
 # @param enabled
 #   If FIPS should be enabled or disabled on the system.
 #
+#   * NOTE: Given the dangerous nature of FIPS unexpectedly being activated on
+#     a system, this module mirrors the existing status of FIPS on the system
+#     to which it is applied.
+#
 # @param aesni
 #   NOTE: This parameter is controlled by params.pp
 #   This parameter indicates wether or not the system uses the
 #   Advanced Encryption Standard New Instructions set.
 #
 class fips (
-  Boolean $enabled = simplib::lookup('simp_options::fips', { 'default_value' => true }),
+  Boolean $enabled = simplib::lookup('simp_options::fips', { 'default_value' => $facts['fips_enabled']}),
   Boolean $aesni   = $::fips::params::aesni
 ) inherits fips::params {
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-fips",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author":  "SIMP Team",
   "summary": "A SIMP module for managing FIPS",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/init_spec.rb
+++ b/spec/acceptance/suites/default/init_spec.rb
@@ -13,6 +13,8 @@ describe 'fips' do
     context 'default parameters and Enable FIPS' do
       # Using puppet_apply as a helper
       it 'should work with no errors' do
+        set_hieradata_on(host, { 'simp_options::fips' => true })
+
         # Must be FIPS compliant!
         # This is typically set during `simp config`
         on(host, 'puppet config set digest_algorithm sha256')
@@ -23,7 +25,7 @@ describe 'fips' do
         result = apply_manifest_on(host, manifest, :catch_failures => true)
         expect(result.output).to include('fips => modified')
 
-        # Reboot to disable fips in the kernel
+        # Reboot to enable fips in the kernel
         host.reboot
       end
 


### PR DESCRIPTION
The FIPS module now enforces, by default, the state of the running
system. This is what we were doing via the `simp config` command but
placing it in the module by default makes the module completely safe for
inclusion on systems that may want to use FIPS in the future.

SIMP-3115 #comment Pinned FIPS version for simp acceptance tests