### PR TITLE
(SIMP-3372) auditd - version/changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,13 @@
-* Fri May 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.3-0
+* Fri May 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.2-0
 - Including the FIPS module was causing FIPS mode to be enabled by default.
   This had high potential for causing issues, as evidenced by our acceptance
   tests, so we now mirror the 'enabled' state of the module based on whether or
   not FIPS is already enabled on the target system.
+- Update puppet dependency in metadata.json
 
 * Fri May 05 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.2-0
 - Created a work-around for an undocumented issue where /boot is not
-  on its own paritition but is added to the kernel parameters with
+  on its own partition but is added to the kernel parameters with
   fips=1. This situation ends up creating a kernel panic on the
   system until the boot= entry is removed from the kernel boot line.
 - Added tests against GCE since that is the default image configuration

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-fips",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "author": "SIMP Team",
   "summary": "A SIMP module for managing FIPS",
   "license": "Apache-2.0",


### PR DESCRIPTION
Last released version was 0.1.1, so next version is 0.1.2