### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,7 +184,7 @@ pup6-unit:
 
 # Acceptance Tests
 # ==============================================================================
-# The acceptance tests turn FIPS on and off, so not BEAKER_fips=yes tests are
+# The acceptance tests turn FIPS on and off, so no BEAKER_fips=yes tests are
 # appropriate.
 pup4.10:
   <<: *pup_4_10

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.1-0
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Thu Oct 11 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.2.0-0
 - Added $dracut_ensure, $fipscheck_ensure and $nss_ensure parameters
   - Changed the packages from 'latest' to 'installed'

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ SIMP Puppet modules are generally intended for use on Red Hat Enterprise Linux a
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 
 ### Acceptance tests

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-fips",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "SIMP Team",
   "summary": "A SIMP module for managing FIPS",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_core",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-fips