### PR TITLE
[SIMP-7220] Trigger global crypto updates on EL8

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,8 +4,7 @@ fixtures:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
+    crypto_policy: https://github.com/simp/pupmod-simp-crypto_policy
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
-  symlinks:
-    fips: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed May 13 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.4.1-0
+- Ensure that EL8 updates trigger updating the global system crypto policy since
+  some subsystems now ignore the local configuration by default.
+
 * Tue Dec 10 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.4.0-0
 - Add EL8 support
 - Add REFERENCE.md

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   * [What fips affects](#what-fips-affects)
 * [> FIPS mode disables md5 hashing at a library level. Enabling it may have unintended consequences.](#-fips-mode-disables-md5-hashing-at-a-library-level-enabling-it-may-have-unintended-consequences)
   * [Beginning with fips](#beginning-with-fips)
+* [> method for propagating your FIPS intentions to all SIMP modules consistently.](#-method-for-propagating-your-fips-intentions-to-all-simp-modules-consistently)
 * [Reference](#reference)
 * [Limitations](#limitations)
 * [Development](#development)
@@ -39,7 +40,6 @@ FIPS mode in supported operating systems.
 This module is a component of the [System Integrity Management Platform](https://simp-project.com),
 a compliance-management framework built on Puppet.
 
-
 If you find any issues, they may be submitted to our [bug tracker](https://simp-project.atlassian.net/).
 
 ## Setup
@@ -61,13 +61,16 @@ If you find any issues, they may be submitted to our [bug tracker](https://simp-
 
 ### Beginning with fips
 
-Include the `fips` class. By default it will enable FIPS mode, but if you'd like
-to ensure that FIPS mode is disabled, call the class and set `fips::enabled:
-false` in hiera.
+Include the `fips` class. By default it **will enable FIPS mode**, but if you'd
+like to ensure that FIPS mode is disabled, call the class and set
+`fips::enabled: false` in hiera.
 
-This section is where you describe how to customize, configure, and do the fancy
-stuff with your module here. It's especially helpful if you include usage
-examples and code samples for doing things with your module.
+-----------------------------------------
+> **IMPORTANT**
+>
+> Setting `simp_options::fips` to either `true` or `false` is the absolute best
+> method for propagating your FIPS intentions to all SIMP modules consistently.
+-----------------------------------------
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ like to ensure that FIPS mode is disabled, call the class and set
 -----------------------------------------
 > **IMPORTANT**
 >
-> Setting `simp_options::fips` to either `true` or `false` is the absolute best
-> method for propagating your FIPS intentions to all SIMP modules consistently.
+> Setting `simp_options::fips` to either `true` or `false` is _by far_ the best
+> method to consistently configure all SIMP modules with your intended FIPS mode.
 -----------------------------------------
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ If you find any issues, they may be submitted to our [bug tracker](https://simp-
 
 ### Beginning with fips
 
-Include the `fips` class. By default it **will enable FIPS mode**, but if you'd
-like to ensure that FIPS mode is disabled, call the class and set
-`fips::enabled: false` in hiera.
+Include the `fips` class.
+
+* By default, this **will enable FIPS mode**.
+* To ensure that FIPS mode is disabled, set `simp_options::fips` to `false`.
+  * Do _not_ set `fips::enabled` directly to `false`―it defaults to the value
+    of `simp_options::fips` (as do the FIPS-related parameters of all other
+    SIMP modules).
 
 -----------------------------------------
 > **IMPORTANT**

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -19,6 +19,10 @@ Changing the FIPS status of a system changes the cryptographic modules used.
 This can affect existing keys and certificates and make them unusable.  Make
 sure these effects are understood before changing the status.
 
+NOTE: The absolute best way of ensuring that your desire to move into FIPS
+mode is set across ALL SIMP modules is to set `simp_options::fips` to `true`
+in Hiera.
+
 #### Parameters
 
 The following parameters are available in the `fips` class.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,10 @@
 # This can affect existing keys and certificates and make them unusable.  Make
 # sure these effects are understood before changing the status.
 #
+# NOTE: The absolute best way of ensuring that your desire to move into FIPS
+# mode is set across ALL SIMP modules is to set `simp_options::fips` to `true`
+# in Hiera.
+#
 # @param enabled
 #   If FIPS should be enabled or disabled on the system.
 #
@@ -25,8 +29,8 @@
 # @param nss_ensure The ensure status of the nss package
 #
 class fips (
-  Boolean $enabled = simplib::lookup('simp_options::fips', { 'default_value' => $facts['fips_enabled']}),
-  Boolean $aesni   = ($facts['cpuinfo'] and member($facts['cpuinfo']['processor0']['flags'], 'aes')),
+  Boolean $enabled          = simplib::lookup('simp_options::fips', { 'default_value' => $facts['fips_enabled']}),
+  Boolean $aesni            = ($facts['cpuinfo'] and member($facts['cpuinfo']['processor0']['flags'], 'aes')),
   String  $dracut_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   String  $fipscheck_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   String  $nss_ensure       = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
@@ -34,98 +38,100 @@ class fips (
 
   simplib::assert_metadata($module_name)
 
-  case $facts['os']['family'] {
-    'RedHat': {
-      $fips_kernel_value = $enabled ? {
-        true    => '1',
-        default => '0'
-      }
+  $fips_kernel_value = $enabled ? {
+    true    => '1',
+    default => '0'
+  }
 
-      # EL 8+ rolls the FIPS portions directly into the base dracut package so
-      # we must NEVER attempt to uninstall it.
-      if $facts['os']['release']['major'] > '7' {
-        if $dracut_ensure == 'absent' {
-          $fips_package_status = 'installed'
-        }
-        else {
-          $fips_package_status = $dracut_ensure
-        }
-      }
-      else {
-        # The dracut packages need to removed/added and the image rebuilt
-        # depending on fips status or the system won't boot properly.
-        $fips_package_status = $enabled ? {
-          true    => $dracut_ensure,
-          default => 'absent'
-        }
-      }
+  # The 'crypto_policy__state' fact will only be populated on systems that
+  # have the crypto policy tools installed.
+  if $facts[crypto_policy__state] {
+    simplib::assert_optional_dependency($module_name, 'simp/crypto_policy')
 
-      kernel_parameter { 'fips':
-        value  => $fips_kernel_value,
-        notify => Reboot_notify['fips']
+    include 'crypto_policy'
+
+    # EL 8+ rolls the FIPS portions directly into the base dracut package so
+    # we must NEVER attempt to uninstall it.
+    if $dracut_ensure == 'absent' {
+      $fips_package_status = 'installed'
+    }
+    else {
+      $fips_package_status = $dracut_ensure
+    }
+  }
+  else {
+    # The dracut packages need to removed/added and the image rebuilt
+    # depending on fips status or the system won't boot properly.
+    $fips_package_status = $enabled ? {
+      true    => $dracut_ensure,
+      default => 'absent'
+    }
+  }
+
+  kernel_parameter { 'fips':
+    value  => $fips_kernel_value,
+    notify => Reboot_notify['fips']
+    # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
+  }
+
+  # This should only be present if /boot is on a separate partition
+  if $facts['boot_dir_uuid'] and $facts['root_dir_uuid'] {
+    if ($facts['boot_dir_uuid'] == $facts['root_dir_uuid']) {
+      kernel_parameter { 'boot':
+        ensure => absent,
+        notify => Reboot_notify['fips'];
         # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
       }
-
-      # This should only be present if /boot is on a separate partition
-      if $facts['boot_dir_uuid'] and $facts['root_dir_uuid'] {
-        if ($facts['boot_dir_uuid'] == $facts['root_dir_uuid']) {
-          kernel_parameter { 'boot':
-            ensure => absent,
-            notify => Reboot_notify['fips'];
-            # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
-          }
-        }
-        else {
-          kernel_parameter { 'boot':
-            value  => "UUID=${facts['boot_dir_uuid']}",
-            notify => Reboot_notify['fips'];
-            # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
-          }
-        }
-      }
-
-      package {
-        'dracut-fips':
-          ensure => $fips_package_status,
-          notify => Exec['dracut_rebuild'];
-
-        'fipscheck':
-          ensure => $fipscheck_ensure
-      }
-
-      if $aesni {
-        package { 'dracut-fips-aesni':
-          ensure => $fips_package_status,
-          notify => Exec['dracut_rebuild']
-        }
-
-        # There were failures if the packages are not removed/installed in the correct
-        # order
-        if $enabled {
-          Package['dracut-fips'] -> Package['dracut-fips-aesni']
-        }
-        else {
-          Package['dracut-fips-aesni'] -> Package['dracut-fips']
-        }
-      }
-
-      reboot_notify { 'fips':
-        reason => 'The status of the fips kernel parameter has changed'
-      }
-
-      # If the NSS and dracut packages don't stay reasonably in sync, your system
-      # may not reboot.
-      package { 'nss':
-        ensure => $nss_ensure
-      }
-
-      exec { 'dracut_rebuild':
-        command     => 'dracut -f',
-        subscribe   => Package['nss'],
-        refreshonly => true,
-        path        => ['/sbin', '/usr/bin'],
-        notify      => Reboot_notify['fips'];
+    }
+    else {
+      kernel_parameter { 'boot':
+        value  => "UUID=${facts['boot_dir_uuid']}",
+        notify => Reboot_notify['fips'];
+        # bootmode => 'normal', # This doesn't work due to a bug in the Grub Augeas Provider
       }
     }
+  }
+
+  package {
+    'dracut-fips':
+      ensure => $fips_package_status,
+      notify => Exec['dracut_rebuild'];
+
+    'fipscheck':
+      ensure => $fipscheck_ensure
+  }
+
+  if $aesni {
+    package { 'dracut-fips-aesni':
+      ensure => $fips_package_status,
+      notify => Exec['dracut_rebuild']
+    }
+
+    # There were failures if the packages are not removed/installed in the correct
+    # order
+    if $enabled {
+      Package['dracut-fips'] -> Package['dracut-fips-aesni']
+    }
+    else {
+      Package['dracut-fips-aesni'] -> Package['dracut-fips']
+    }
+  }
+
+  reboot_notify { 'fips':
+    reason => 'The status of the fips kernel parameter has changed'
+  }
+
+  # If the NSS and dracut packages don't stay reasonably in sync, your system
+  # may not reboot.
+  package { 'nss':
+    ensure => $nss_ensure
+  }
+
+  exec { 'dracut_rebuild':
+    command     => 'dracut -f',
+    subscribe   => Package['nss'],
+    refreshonly => true,
+    path        => ['/sbin', '/usr/bin'],
+    notify      => Reboot_notify['fips'];
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,9 +6,8 @@
 # This can affect existing keys and certificates and make them unusable.  Make
 # sure these effects are understood before changing the status.
 #
-# NOTE: The absolute best way of ensuring that your desire to move into FIPS
-# mode is set across ALL SIMP modules is to set `simp_options::fips` to `true`
-# in Hiera.
+# NOTE: The preferred method yo set FIPS mode consistently across ALL
+# ALL SIMP modules is to set `simp_options::fips` to `true` in Hiera.
 #
 # @param enabled
 #   If FIPS should be enabled or disabled on the system.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class fips (
 
   # The 'crypto_policy__state' fact will only be populated on systems that
   # have the crypto policy tools installed.
-  if $facts[crypto_policy__state] {
+  if $facts['crypto_policy__state'] {
     simplib::assert_optional_dependency($module_name, 'simp/crypto_policy')
 
     include 'crypto_policy'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-fips",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "SIMP Team",
   "summary": "A SIMP module for managing FIPS",
   "license": "Apache-2.0",
@@ -29,6 +29,14 @@
       "version_requirement": ">= 2.3.1 < 4.0.0"
     }
   ],
+  "simp": {
+    "optional_dependencies": [
+      {
+        "name": "simp/crypto_policy",
+        "version_requirement": ">= 0.1.0 < 2.0.0"
+      }
+    ]
+  },
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,22 +9,16 @@ HOSTS:
   el6:
     roles:
       - default
-      - master
-      - client
     platform: el-6-x86_64
     box: centos/6
     hypervisor: <%= hypervisor %>
 
   el7:
-    roles:
-      - client
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
 
   el8:
-    roles:
-      - client
     platform: el-8-x86_64
     box: centos/8
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -25,6 +25,13 @@ describe 'fips' do
         result = apply_manifest_on(host, manifest, :catch_failures => true)
         expect(result.output).to include('fips => The status of the fips kernel parameter has changed')
 
+        # Hack to allow Vagrant to SSH back into the system (should really fix
+        # this in Vagrant if possible)
+        opensshserver_config = '/etc/crypto-policies/back-ends/opensshserver.config'
+        if file_exists_on(host, opensshserver_config)
+          on(host, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{opensshserver_config}")
+        end
+
         # Reboot to enable fips in the kernel
         host.reboot
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -76,11 +76,22 @@ describe 'fips' do
         end
 
         context 'when_disabling_fips and aes' do
+          if os_facts[:os][:release][:major] > '7'
+            let(:crypto_policy__state){{
+              'global_policy'             => 'DEFAULT',
+              'global_policy_applied'     => true,
+              'global_policies_available' => ['DEAFULT', 'FIPS']
+            }}
+          else
+            let(:crypto_policy__state){ nil }
+          end
+
           let(:facts){
             os_facts.merge({
             :cpuinfo => { :processor0 => { :flags => ['aes'] }},
             :root_dir_uuid => '123-456-789',
-            :boot_dir_uuid => '123-456-790'
+            :boot_dir_uuid => '123-456-790',
+            :crypto_policy__state => crypto_policy__state
             })
           }
 


### PR DESCRIPTION
- Ensure that EL8 updates trigger updating the global system crypto policy since
  some subsystems now ignore the local configuration by default.
- The acceptance tests for this probably won't work until
  https://github.com/puppetlabs/beaker/pull/1643 gets released due to
  bugs in the reboot detection code.

SIMP-7220 #close