### PR TITLE
(SIMP-8958) Standardize assets in pupmod-simp-fips

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,11 +45,13 @@ variables:
   BUNDLE_NO_PRUNE:   'true'
 
 
-# bundler dependencies + caching, optional RVM setup, with diagnostic output
-# --------------------------------------------------------------------------
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
 .setup_bundler_env: &setup_bundler_env
   cache:
-    # Cache bundler gems between pipelines for each Ruby version
     key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
     paths:
       - '.vendor'
@@ -91,31 +93,32 @@ variables:
 
 # Assign a matrix level when your test will run.  Heavier jobs get higher numbers
 # NOTE: To skip all jobs with a SIMP_MATRIX_LEVEL, set SIMP_MATRIX_LEVEL=0
-# ------------------------------------------------------------------------------
 
 .relevant_file_conditions_trigger_spec_tests: &relevant_file_conditions_trigger_spec_tests
   changes:
     - .gitlab-ci.yml
     - .fixtures.yml
-    - .rspec
-    - metadata.json
     - "spec/spec_helper.rb"
     - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*.rb"
-    - "{SIMP,data,manifests,files,types,lib}/**/*"
+    - "{SIMP,data,manifests,files,types,lib,functions}/**/*"
     - "templates/**/*.{erb,epp}"
     - "Gemfile"
+    - "SIMP/**/*"
+    - "data/**/*"
   exists:
-    - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*_spec.rb"
+    - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*_spec.rb"
 
 .relevant_file_conditions_trigger_acceptance_tests: &relevant_file_conditions_trigger_acceptance_tests
   changes:
     - .gitlab-ci.yml
-    - .fixtures.yml
     - "spec/spec_helper_acceptance.rb"
     - "spec/{helpers,acceptance}/**/*"
-    - "{SIMP,data,manifests,files,types,lib}/**/*"
+    - "spec/inspec_*/**/*"
+    - "{SIMP,data,manifests,files,types,lib,functions}/**/*"
     - "templates/**/*.{erb,epp}"
     - "Gemfile"
+    - "SIMP/**/*"
+    - "data/**/*"
   exists:
     - "spec/acceptance/**/*_spec.rb"
 
@@ -216,28 +219,35 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_5: &pup_5
+.pup_5_x: &pup_5_x
   image: 'ruby:2.4'
   variables:
     PUPPET_VERSION: '~> 5.0'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_6: &pup_6
+.pup_5_pe: &pup_5_pe
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '5.5.20'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_6_x: &pup_6_x
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_6_18_0: &pup_6_18_0
+.pup_6_pe: &pup_6_pe
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '6.18.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
-.pup_7: &pup_7
+.pup_7_x: &pup_7_x
   image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
@@ -281,7 +291,7 @@ variables:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_5
+  <<: *pup_5_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -297,31 +307,39 @@ releng_checks:
 # Linting
 #-----------------------------------------------------------------------
 
+# NOTE: Don't add more lint checks here.
+#       puppet-lint is a validator, not a parser; it includes its own lexer and
+#       doesn't use the Puppet gem at all.  Running multiple lint tests against
+#       different Puppet versions won't accomplish anything.
+
 pup-lint:
-  <<: *pup_6
+  <<: *pup_6_x
   <<: *lint_tests
 
 # Unit Tests
 #-----------------------------------------------------------------------
 
-pup5-unit:
-  <<: *pup_5
+pup5.x-unit:
+  <<: *pup_5_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6-unit:
-  <<: *pup_6
+pup5.pe-unit:
+  <<: *pup_5_pe
+  <<: *unit_tests
+
+pup6.x-unit:
+  <<: *pup_6_x
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup6.18.0-unit:
-  <<: *pup_6_18_0
+pup6.pe-unit:
+  <<: *pup_6_pe
   <<: *unit_tests
 
-pup7-unit:
-  <<: *pup_7
+pup7.x-unit:
+  <<: *pup_7_x
   <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**
@@ -335,34 +353,34 @@ pup7-unit:
 
 # The acceptance tests turn FIPS on and off, so no BEAKER_fips=yes tests are
 # appropriate.
-pup5:
-  <<: *pup_5
+pup5.x:
+  <<: *pup_5_x
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup6:
-  <<: *pup_6
+pup6.x:
+  <<: *pup_6_x
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup6.18.0:
-  <<: *pup_6_18_0
+pup6.pe:
+  <<: *pup_6_pe
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup6.18.0-oel:
-  <<: *pup_6_18_0
+pup6.pe-oel:
+  <<: *pup_6_pe
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup7:
-  <<: *pup_7
+pup7.x:
+  <<: *pup_7_x
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 5.5'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version
@@ -24,7 +24,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.11.5', '< 6']
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
 end
 
@@ -37,7 +37,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.19.3', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist


### PR DESCRIPTION
This patch baselines the latest standardized assets for Puppet modules.

SIMP-8998 #close
[SIMP-8958] #comment Standardized assets in pupmod-simp-fips
[SIMP-8839] #comment Removed EL6 from pupmod-simp-fips
[SIMP-8489] #comment Updated pupmod-simp-fips GLCI pipeline to Puppet 6.18
[SIMP-8923] #comment Renamed 'sanity' to 'releng' in pupmod-simp-fips
[SIMP-8984] #comment Updated pupmod-simp-fips to new GLCI conventions

[SIMP-8958]: https://simp-project.atlassian.net/browse/SIMP-8958
[SIMP-8839]: https://simp-project.atlassian.net/browse/SIMP-8839
[SIMP-8489]: https://simp-project.atlassian.net/browse/SIMP-8489
[SIMP-8923]: https://simp-project.atlassian.net/browse/SIMP-8923
[SIMP-8984]: https://simp-project.atlassian.net/browse/SIMP-8984