### PR TITLE
(SIMP-9141) Fix crypto policy fact source

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Jan 21 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.4.5
+- Fixed:
+  - Now use the simplib__crypto_policy_state fact instead of
+    crypto_policy__state due to module dependency issues.
+
 * Wed Dec 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.4.4
 - Fixed:
   - Ensure that dracut_rebuild is called when the fips kernel parameter is

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.21.3', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,7 +10,7 @@
 
 ## Classes
 
-### `fips`
+### <a name="fips"></a>`fips`
 
 This module manages the enabling and disabling of FIPS on a system
 It will set the kernel boot parametes and install/remove the dracut packages
@@ -25,9 +25,15 @@ ALL SIMP modules is to set `simp_options::fips` to `true` in Hiera.
 
 #### Parameters
 
-The following parameters are available in the `fips` class.
+The following parameters are available in the `fips` class:
 
-##### `enabled`
+* [`enabled`](#enabled)
+* [`aesni`](#aesni)
+* [`dracut_ensure`](#dracut_ensure)
+* [`fipscheck_ensure`](#fipscheck_ensure)
+* [`nss_ensure`](#nss_ensure)
+
+##### <a name="enabled"></a>`enabled`
 
 Data type: `Boolean`
 
@@ -39,7 +45,7 @@ If FIPS should be enabled or disabled on the system.
 
 Default value: `simplib::lookup('simp_options::fips', { 'default_value' => $facts['fips_enabled']})`
 
-##### `aesni`
+##### <a name="aesni"></a>`aesni`
 
 Data type: `Boolean`
 
@@ -48,7 +54,7 @@ Advanced Encryption Standard New Instructions set.
 
 Default value: `(`
 
-##### `dracut_ensure`
+##### <a name="dracut_ensure"></a>`dracut_ensure`
 
 Data type: `String`
 
@@ -57,7 +63,7 @@ dracut-fips-aesni packages
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-##### `fipscheck_ensure`
+##### <a name="fipscheck_ensure"></a>`fipscheck_ensure`
 
 Data type: `String`
 
@@ -65,7 +71,7 @@ The ensure status of the fipscheck package
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-##### `nss_ensure`
+##### <a name="nss_ensure"></a>`nss_ensure`
 
 Data type: `String`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class fips (
 
   # The 'crypto_policy__state' fact will only be populated on systems that
   # have the crypto policy tools installed.
-  if $facts['crypto_policy__state'] {
+  if $facts['simplib__crypto_policy_state'] {
     simplib::assert_optional_dependency($module_name, 'simp/crypto_policy')
 
     include 'crypto_policy'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-fips",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": "SIMP Team",
   "summary": "A SIMP module for managing FIPS",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.3.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -77,13 +77,13 @@ describe 'fips' do
 
         context 'when_disabling_fips and aes' do
           if os_facts[:os][:release][:major] > '7'
-            let(:crypto_policy__state){{
+            let(:simplib__crypto_policy_state){{
               'global_policy'             => 'DEFAULT',
               'global_policy_applied'     => true,
-              'global_policies_available' => ['DEAFULT', 'FIPS']
+              'global_policies_available' => ['DEFAULT', 'FIPS']
             }}
           else
-            let(:crypto_policy__state){ nil }
+            let(:simplib__crypto_policy_state){ nil }
           end
 
           let(:facts){
@@ -91,7 +91,7 @@ describe 'fips' do
             :cpuinfo => { :processor0 => { :flags => ['aes'] }},
             :root_dir_uuid => '123-456-789',
             :boot_dir_uuid => '123-456-790',
-            :crypto_policy__state => crypto_policy__state
+            :simplib__crypto_policy_state => simplib__crypto_policy_state
             })
           }
 


### PR DESCRIPTION
- Fixed:
  - Now use the simplib__crypto_policy_state fact instead of
    crypto_policy__state due to module dependency issues.

SIMP-9141 #close