### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -15,7 +15,7 @@ HOSTS:
 
   el8:
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -9,11 +9,10 @@ HOSTS:
   oel7:
     roles:
       - client
-      # roles migrated from now-removed el6 node(s): 
       - default
       - master
     platform: el-7-x86_64
-    box: onyxpoint/oel-7-x86_64
+    box: generic/oracle7
     hypervisor: <%= hypervisor %>
 
   oel8:

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -25,12 +25,7 @@ describe 'fips' do
         result = apply_manifest_on(host, manifest, :catch_failures => true)
         expect(result.output).to include('fips => The status of the fips kernel parameter has changed')
 
-        # Hack to allow Vagrant to SSH back into the system (should really fix
-        # this in Vagrant if possible)
-        opensshserver_config = '/etc/crypto-policies/back-ends/opensshserver.config'
-        if file_exists_on(host, opensshserver_config)
-          on(host, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{opensshserver_config}")
-        end
+        munge_ssh_crypto_policies(host)
 
         # Reboot to enable fips in the kernel
         host.reboot

--- a/spec/acceptance/suites/gce/00_default_spec.rb
+++ b/spec/acceptance/suites/gce/00_default_spec.rb
@@ -1,0 +1,1 @@
+../default/00_default_spec.rb

--- a/spec/acceptance/suites/gce/init_spec.rb
+++ b/spec/acceptance/suites/gce/init_spec.rb
@@ -1,1 +1,0 @@
-../default/init_spec.rb

--- a/spec/acceptance/suites/gce/nodesets/default.yml
+++ b/spec/acceptance/suites/gce/nodesets/default.yml
@@ -2,7 +2,6 @@ HOSTS:
   el7:
     roles:
       - server
-      # roles migrated from now-removed el6 node(s): 
       - client
       - default
       - master


### PR DESCRIPTION
- update the EL8 nodes in the acceptance tests
  to run with generic/centos8 to make sure they using
  CentOS 8.4
- updated oel box to generic from onyxpoint

SIMP-10204 #comment updated fips
SIMP-10218 #close