### PR TITLE
Finalize RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -117,6 +117,7 @@ jobs:
             puppet_version: '~> 8.0'
             ruby_version: 3.1
             experimental: true
+      fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,6 +340,7 @@ pup7.pe-unit:
   <<: *pup_7_pe
   <<: *unit_tests
 
+# Commenting until Puppet 8 is released
 #pup8.x-unit:
 #  <<: *pup_8_x
 #  <<: *unit_tests

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :system_tests do
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.28.0', '< 2']
   gem 'bcrypt_pbkdf'
-  gem 'net-ssh', '< 7.0' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end
 
 # Evaluate extra gemfiles if they exist

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,13 +27,21 @@ ALL SIMP modules is to set `simp_options::fips` to `true` in Hiera.
 
 The following parameters are available in the `fips` class:
 
-* [`enabled`](#enabled)
-* [`aesni`](#aesni)
-* [`dracut_ensure`](#dracut_ensure)
-* [`fipscheck_ensure`](#fipscheck_ensure)
-* [`nss_ensure`](#nss_ensure)
+* [`fipscheck_package_name`](#-fips--fipscheck_package_name)
+* [`enabled`](#-fips--enabled)
+* [`aesni`](#-fips--aesni)
+* [`dracut_ensure`](#-fips--dracut_ensure)
+* [`fipscheck_ensure`](#-fips--fipscheck_ensure)
+* [`nss_ensure`](#-fips--nss_ensure)
 
-##### <a name="enabled"></a>`enabled`
+##### <a name="-fips--fipscheck_package_name"></a>`fipscheck_package_name`
+
+Data type: `String`
+
+The name of the package that provides the
+fipscheck binary
+
+##### <a name="-fips--enabled"></a>`enabled`
 
 Data type: `Boolean`
 
@@ -45,16 +53,16 @@ If FIPS should be enabled or disabled on the system.
 
 Default value: `simplib::lookup('simp_options::fips', { 'default_value' => $facts['fips_enabled']})`
 
-##### <a name="aesni"></a>`aesni`
+##### <a name="-fips--aesni"></a>`aesni`
 
 Data type: `Boolean`
 
 This parameter indicates whether the system uses the
 Advanced Encryption Standard New Instructions set.
 
-Default value: `(`
+Default value: `($facts['cpuinfo'] and member($facts['cpuinfo']['processor0']['flags'], 'aes')`
 
-##### <a name="dracut_ensure"></a>`dracut_ensure`
+##### <a name="-fips--dracut_ensure"></a>`dracut_ensure`
 
 Data type: `String`
 
@@ -63,7 +71,7 @@ dracut-fips-aesni packages
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-##### <a name="fipscheck_ensure"></a>`fipscheck_ensure`
+##### <a name="-fips--fipscheck_ensure"></a>`fipscheck_ensure`
 
 Data type: `String`
 
@@ -71,7 +79,7 @@ The ensure status of the fipscheck package
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-##### <a name="nss_ensure"></a>`nss_ensure`
+##### <a name="-fips--nss_ensure"></a>`nss_ensure`
 
 Data type: `String`
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.